### PR TITLE
Fix Account.swift after parameters rename

### DIFF
--- a/Sources/Appwrite/Services/Account.swift
+++ b/Sources/Appwrite/Services/Account.swift
@@ -1014,8 +1014,8 @@ open class Account: Service {
             "project": client.config["project"]
         ]
 
-        let query = "?\(client.parametersToQueryString(params: params))"
-        let url = URL(string: client.endPoint + api_path + query)!
+        let query = "?\(client.parametersToQueryString(params: apiParams))"
+        let url = URL(string: client.endPoint + apiPath + query)!
         let callbackScheme = "appwrite-callback-\(client.config["project"] ?? "")"
         let group = DispatchGroup()
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes incorrectly renamed parameters in Account.swift file, which prevents projects using Appwrite SDK from building.

## Test Plan

Project started building after fixing compiler errors.

## Related PRs and Issues

—

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.