### PR TITLE
feat: Apple SDK update for version 13.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 13.2.2
+
+* Fix issue: Missing AppwriteEnums dependency causing build failure
+
 ## 13.2.1
 
 * Add transaction support for Databases and TablesDB

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         .target(
             name: "AppwriteModels",
             dependencies: [
+                "AppwriteEnums",
                 "JSONCodable"
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the package to your `Package.swift` dependencies:
 
 ```swift
     dependencies: [
-        .package(url: "git@github.com:appwrite/sdk-for-apple.git", from: "13.2.1"),
+        .package(url: "git@github.com:appwrite/sdk-for-apple.git", from: "13.2.2"),
     ],
 ```
 

--- a/Sources/Appwrite/Client.swift
+++ b/Sources/Appwrite/Client.swift
@@ -23,7 +23,7 @@ open class Client {
         "x-sdk-name": "Apple",
         "x-sdk-platform": "client",
         "x-sdk-language": "apple",
-        "x-sdk-version": "13.2.1",
+        "x-sdk-version": "13.2.2",
         "x-appwrite-response-format": "1.8.0"
     ]
 


### PR DESCRIPTION
This PR contains updates to the Apple SDK for version 13.2.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical build failure caused by a missing dependency that prevented compilation of the SDK. The dependency has been added to the package configuration.

* **Chores**
  * Updated version references and documentation to reflect version 13.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->