### PR TITLE
chore: bump SDK version to 17.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the package to your `Package.swift` dependencies:
 
 ```swift
     dependencies: [
-        .package(url: "git@github.com:appwrite/sdk-for-apple.git", from: "17.1.1"),
+        .package(url: "git@github.com:appwrite/sdk-for-apple.git", from: "17.2.0"),
     ],
 ```
 

--- a/docs/examples/avatars/get-screenshot.md
+++ b/docs/examples/avatars/get-screenshot.md
@@ -21,7 +21,7 @@ let bytes = try await avatars.getScreenshot(
     userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15", // optional
     fullpage: true, // optional
     locale: "en-US", // optional
-    timezone: .americaNewYork, // optional
+    timezone: .africaAbidjan, // optional
     latitude: 37.7749, // optional
     longitude: -122.4194, // optional
     accuracy: 100, // optional


### PR DESCRIPTION
This PR bumps the SDK package version to 17.2.0 after the concurrent chunk upload update.